### PR TITLE
feat: improve CI publishing

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,3 +28,28 @@ jobs:
     - run: npm install
     - run: npm run build --if-present
     - run: npm test
+
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js latest
+      uses: actions/setup-node@v3
+      with:
+        node-version: latest
+
+    - name: get-npm-version
+      uses: martinbeentjes/npm-get-version-action@v1.3.1
+      id: package-version
+
+    - run: npm install
+    - run: npm run build
+    - run: npm config set registry https://registry.npmjs.org 
+    - run: npm config set _authToken=${{ secrets.NPM_TOKEN }}
+    - run: npm config fix
+    - run: npm version --no-git-tag-version ${{ steps.package-version.outputs.current-version}}-${{ github.head_ref }}${{ github.sha }}
+    - run: npm publish --access public --tag ${{ github.head_ref }}-${{ github.sha }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+


### PR DESCRIPTION
This publishes a draft release into npm see: https://www.npmjs.com/package/@artaio/arta-browser?activeTab=versions & https://www.npmjs.com/package/@artaio/arta-browser/v/2.3.13-improve-ci3338a8925bb4a3108159b4b0af134bee32f58c27

This is a feat commit rather than a ci commit otherwise it would skip-ci and we would be not able to check if it works.