### PR TITLE
chore: renames Transit Insurance to Shipping Protection

### DIFF
--- a/lib/components/DrawerInsurance/index.tsx
+++ b/lib/components/DrawerInsurance/index.tsx
@@ -2,7 +2,7 @@ export const DrawerInsurance = () => {
   return (
     <div class="artajs__tracking__insurance__wrapper">
       <div class="artajs__tracking__insurance__content">
-        <div class="artajs__tracking__insurance__title">Protected with</div>
+        <div class="artajs__tracking__insurance__title">Covered by</div>
         <div class="artajs__tracking__insurance__body">
           <div class="artajs__tracking__insurance__body__icon">
             <svg
@@ -31,7 +31,7 @@ export const DrawerInsurance = () => {
             target="_blank"
             class="artajs__tracking__insurance__body__icon__text"
           >
-            Arta Transit Insurance
+            Arta Shipping Protection
           </a>
         </div>
       </div>

--- a/lib/components/Quotes/index.tsx
+++ b/lib/components/Quotes/index.tsx
@@ -10,7 +10,7 @@ export const defaultQuoteConfig = {
   disclaimerLabel: 'Actual shipping costs will be provided at checkout.',
   rangeLabel: 'Shipping estimated between',
   startsAtLabel: 'Shipping Starts at',
-  artaInsuranceLabel: 'This estimate includes Arta Transit Insurance.',
+  artaInsuranceLabel: 'This estimate includes Arta Shipping Protection.',
 };
 
 export interface QuoteTextConfig {


### PR DESCRIPTION
Reflecting a larger renaming of Arta's coverage product for shipments, we are updating the language in Estimates and Tracking widgets.