### PR TITLE
feat: adds showThumbnails configuration to embedded tracking

### DIFF
--- a/lib/components/Package/index.tsx
+++ b/lib/components/Package/index.tsx
@@ -1,16 +1,16 @@
-import type { TrackingConfig } from '../../trackingConfig';
+import type { TrackingFullConfig } from '../../trackingConfig';
 import { Pill } from '../Pill';
 import type { ArtaObject, Shipment } from '../TrackingDrawer';
 
 export interface PackingsProps {
   shipment: Shipment;
-  config: TrackingConfig;
+  config: TrackingFullConfig;
   pkg: Shipment['packages'][number];
   title: string;
   setPackageId: (value: number) => void;
 }
 
-export const objectDetailTitle = (obj: ArtaObject, config: TrackingConfig) => {
+export const objectDetailTitle = (obj: ArtaObject, config: TrackingFullConfig) => {
   if (
     obj.details?.title == null &&
     obj.details?.creator == null &&
@@ -96,16 +96,36 @@ export const Package = ({
         <div class="artajs__packings__line" />
 
         <div class="artajs__packings__item">
-          {pkg.objects.map((obj) => (
-            <div class="artajs__packings__item__content">
-              {
-                <div class="artajs__tracking__title">
-                  {objectDetailTitle(obj, config)}
+          {pkg.objects.map((obj) => {
+            const hasImage = obj.shipment_object_images && obj.shipment_object_images.length > 0;
+            const thumbnailUrl = hasImage && obj.shipment_object_images
+              ? `${config.httpSchema}://${config.host}/shipment_images/60x60/resize/${obj.shipment_object_images[0].filename}`
+              : null;
+
+            return (
+              <div class="artajs__packings__item__row">
+                {config.showThumbnails && (
+                  <div class="artajs__packings__item__thumbnail">
+                    {thumbnailUrl ? (
+                      <img
+                        src={thumbnailUrl}
+                        alt="shipment object image"
+                        class="artajs__packings__item__thumbnail__img"
+                      />
+                    ) : (
+                      <div class="artajs__packings__item__thumbnail__placeholder" />
+                    )}
+                  </div>
+                )}
+                <div class="artajs__packings__item__content">
+                  <div class="artajs__tracking__title">
+                    {objectDetailTitle(obj, config)}
+                  </div>
+                  <div class="artajs__tracking__subtype">{obj.subtype_name}</div>
                 </div>
-              }
-              <div class="artajs__tracking__subtype">{obj.subtype_name}</div>
-            </div>
-          ))}
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/lib/components/SelectTrackingShipment/index.tsx
+++ b/lib/components/SelectTrackingShipment/index.tsx
@@ -108,18 +108,38 @@ export const SelectTrackingShipment = ({
               .filter((pkg) => pkg?.objects?.length)
               .map((pkg) => (
                 <div class="artajs__packings__item">
-                  {pkg.objects.map((obj) => (
-                    <div class="artajs__packings__item__content">
-                      {
-                        <div class="artajs__tracking__title">
-                          {objectDetailTitle(obj, config)}
+                  {pkg.objects.map((obj) => {
+                    const hasImage = obj.shipment_object_images && obj.shipment_object_images.length > 0;
+                    const thumbnailUrl = hasImage && obj.shipment_object_images
+                      ? `${config.httpSchema}://${config.host}/shipment_images/60x60/resize/${obj.shipment_object_images[0].filename}`
+                      : null;
+
+                    return (
+                      <div class="artajs__packings__item__row">
+                        {config.showThumbnails && (
+                          <div class="artajs__packings__item__thumbnail">
+                            {thumbnailUrl ? (
+                              <img
+                                src={thumbnailUrl}
+                                alt="shipment object image"
+                                class="artajs__packings__item__thumbnail__img"
+                              />
+                            ) : (
+                              <div class="artajs__packings__item__thumbnail__placeholder" />
+                            )}
+                          </div>
+                        )}
+                        <div class="artajs__packings__item__content">
+                          <div class="artajs__tracking__title">
+                            {objectDetailTitle(obj, config)}
+                          </div>
+                          <div class="artajs__tracking__subtype">
+                            {obj.subtype_name}
+                          </div>
                         </div>
-                      }
-                      <div class="artajs__tracking__subtype">
-                        {obj.subtype_name}
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               ))}
 

--- a/lib/components/TrackingDrawer/index.css
+++ b/lib/components/TrackingDrawer/index.css
@@ -645,11 +645,37 @@
   align-self: stretch;
 }
 
+.artajs__drawer .artajs__packings__item__row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  align-self: stretch;
+}
+
+.artajs__drawer .artajs__packings__item__thumbnail {
+  flex-shrink: 0;
+}
+
+.artajs__drawer .artajs__packings__item__thumbnail__img {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 2px;
+  border: 1px solid var(--border);
+}
+
+.artajs__drawer .artajs__packings__item__thumbnail__placeholder {
+  width: 48px;
+  height: 48px;
+  border-radius: 2px;
+  border: 1px solid var(--border);
+}
+
 .artajs__drawer .artajs__packings__item__content {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  align-self: stretch;
+  flex: 1;
 }
 
 .artajs__drawer .artajs__packings__text__wrapper {

--- a/lib/components/TrackingDrawer/index.tsx
+++ b/lib/components/TrackingDrawer/index.tsx
@@ -52,6 +52,10 @@ export interface ArtaObject {
   subtype: string;
   subtype_name: string;
   type: string;
+  shipment_object_images?: Array<{
+    filename: string;
+    url: string;
+  }>;
 }
 
 export interface ArtaPackage {

--- a/lib/requests.ts
+++ b/lib/requests.ts
@@ -32,7 +32,6 @@ export interface ArtaError {
 const AUTH_KEY = 'ARTA_APIKey';
 
 const logError = ({ status, errors }: ArtaError): void => {
-  console.log(errors);
   const keys = Object.keys(errors);
   if (status === 403) {
     console.error('Invalid API Key');

--- a/lib/trackingConfig.ts
+++ b/lib/trackingConfig.ts
@@ -79,6 +79,7 @@ export interface TrackingConfig {
     backdropEnabled: boolean;
     backdropColor: string;
   };
+  showThumbnails?: boolean;
   text: {
     header: {
       title: string;
@@ -149,6 +150,7 @@ export const defaultTrackingConfig: TrackingConfig = {
   navigation: {
     shipmentExceptionMailTo: 'hello@arta.io',
   },
+  showThumbnails: false,
   style: {
     color: {
       background: '#FFFFFF',


### PR DESCRIPTION
This PR introduces `showThumbnails` to the tracking config (default: `false`). When `showThumbnails` is set to true, the tracking widget will present an object thumbnail image in the tracking drawer beside the object details

Shipment Detail
<img width="597" height="948" alt="image" src="https://github.com/user-attachments/assets/f57b2c1d-f7b9-483b-aec5-ed6e665a2d25" />

Multiple Shipment List
<img width="625" height="943" alt="image" src="https://github.com/user-attachments/assets/5a8c4a75-a47d-439f-b897-84ecc1ea9963" />

---

The tracking widget presentation is otherwise unchanged when `showThumbnails` is false.

Shipment Detail
<img width="604" height="935" alt="image" src="https://github.com/user-attachments/assets/350071e7-38a4-41da-914b-4c35e080ea52" />

Multiple Shipment List
<img width="587" height="936" alt="image" src="https://github.com/user-attachments/assets/24ac1a1f-3497-4e2e-8e31-d2b706ab7395" />

