### PR TITLE
chore: Added "Three Day" service 🐧 

### DIFF
--- a/lib/MetadataTypes.ts
+++ b/lib/MetadataTypes.ts
@@ -292,6 +292,7 @@ export type ParcelTransportServices =
   | 'priority'
   | 'priority_freight'
   | 'second_day_air'
+  | 'three_day'
   | 'standard';
 
 export type WebhookDeliveryType =


### PR DESCRIPTION
Since we've introduced a new service level, called "Three Day", we needed to add it to appropriate places in the codebase.

This PR does it.