### PR TITLE
security-test: validate GHA hardening

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,5 +1,9 @@
 name: Build and Publish
 
+# Security test: this comment was added by an external account (SyntaxSmith106)
+# to validate that workflow-file modifications by non-collaborators do not auto-run
+# and that malicious branch names cannot inject shell commands. Safe to revert.
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Comment-only change to .github/workflows/build-and-publish.yml. Combined with the malicious branch name carrying a `$(...)`/single-quote-break payload, this PR exercises two protections introduced in #71:

1. Script injection via `${{ github.head_ref }}` interpolation — the previously-vulnerable publish-draft job was removed, so the payload should produce no command execution in workflow logs.
2. External-contributor workflow modification — GitHub should require manual approval before running workflows on this PR.

Revert after validation.